### PR TITLE
Utilise un fichier de config pour gérer les secrets

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,0 +1,15 @@
+const env = process.env.NODE_ENV || 'development';
+
+const all = {
+  env,
+  passwordSalt: process.env.PASSWORD_SALT || 'salty',
+};
+
+try {
+  const override = require(`./env/${env}`); // eslint-disable-line
+  console.info(`Using specific configuration for ${env}.`); // eslint-disable-line
+  module.exports = Object.assign(all, override);
+} catch (e) {
+  console.warn(`No specific configuration for ${env}.`); // eslint-disable-line
+  module.exports = all;
+}

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -1,16 +1,15 @@
 const crypto = require('crypto');
-
-const salt = 'salt';
+const { passwordSalt } = require('./config');
 const iterations = 100000;
 const keylen = 64;
 const digest = 'sha512';
 
 function pbkdf2(password, callback) {
-  return crypto.pbkdf2(password, salt, iterations, keylen, digest, callback);
+  return crypto.pbkdf2(password, passwordSalt, iterations, keylen, digest, callback);
 }
 
 function pbkdf2Sync(password) {
-  return crypto.pbkdf2Sync(password, salt, iterations, keylen, digest);
+  return crypto.pbkdf2Sync(password, passwordSalt, iterations, keylen, digest);
 }
 
 module.exports = {


### PR DESCRIPTION
Le [`salt`](https://en.wikipedia.org/wiki/Salt_(cryptography)) utilisé pour le hachage des mots de passe en production doit rester privé.