### PR TITLE
 Enregistre l'utilisateur dans un cookie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -833,6 +833,15 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
+    "cookie-parser": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
+      "integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6"
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "body-parser": "^1.18.3",
     "consolidate": "^0.15.1",
+    "cookie-parser": "^1.4.4",
     "express": "^4.16.4",
     "mustache": "^3.0.1",
     "pm2": "^3.5.0",

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -3,6 +3,7 @@ const env = process.env.NODE_ENV || 'development';
 const all = {
   env,
   passwordSalt: process.env.PASSWORD_SALT || 'salty',
+  cookieSecret: process.env.COOKIE_SECRET || 'honey',
 };
 
 try {


### PR DESCRIPTION
Pour éviter la saisie des identifiants, il est intéressant de stocker l'information de connexion dans un cookie. Ce cookie doit être signé, avec un secret, pour qu'il ne puisse pas être [_forger_](https://fr.wiktionary.org/wiki/forger).

À ne pas _merger_ avant #2 